### PR TITLE
Development with docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM rubylang/ruby:2.6.4-bionic
+WORKDIR /ruboty-ruby-jp
+
+RUN apt update \
+    && apt install -y g++ \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY Gemfile Gemfile.lock /ruboty-ruby-jp/
+RUN bundle install
+
+COPY . .

--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ $ bundle install
 $ REDIS_URL=redis://localhost:6379/ RUBOTY_CLI=1 bundle exec ruby main.rb
 ```
 
+If you have docker environment, also can development by run below command
+```bash
+$ docker-compose run ruboty
+```
+
 
 
 Contributing

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3'
+services:
+  ruboty:
+    build: .
+    volumes:
+      - .:/ruboty-ruby-jp
+    environment:
+      - REDIS_URL=redis://redis:6379
+      - RUBOTY_CLI=1
+    command: bundle exec ruby main.rb
+    stdin_open: true
+    tty: true
+    links:
+      - redis
+  redis:
+    image: redis


### PR DESCRIPTION
Ruboty needs redis but setup is boring.

![Screenshot from 2019-10-09 12-11-11](https://user-images.githubusercontent.com/4487291/66449033-981ffe80-ea8e-11e9-903b-5e9d941ab93f.png)
https://ruby-jp.slack.com/archives/CM4JN63D3/p1570526881018800

```bash
% docker-compose run ruboty
Starting ruboty-ruby-jp_redis_1 ... done
Type `exit` or `quit` to end the session.
> ruboty matz
:matz1::matz2::matz3:
:matz4::matz5::matz6:
:matz7::matz8::matz9:
> quit
```
