### PR TITLE
リンク化するためチャンネル名に#を付加するよう修正

### DIFF
--- a/ruboty-channel-gacha.rb
+++ b/ruboty-channel-gacha.rb
@@ -23,7 +23,7 @@ module Ruboty
 
       def format(channel)
         <<~MESSAGE
-          チャンネル名: #{channel.name}
+          チャンネル名: ##{channel.name}
           トピック: #{channel.topic.presence || '未設定'}
           説明: #{channel.purpose.presence || '未設定'}
         MESSAGE


### PR DESCRIPTION
- ガチャ結果からチャンネルに飛べると便利なので、チャンネル名に#を付加してリンク化

### 指摘元
[![Image from Gyazo](https://i.gyazo.com/e49b5c6922579230104799ea7bc77c64.png)](https://gyazo.com/e49b5c6922579230104799ea7bc77c64)