### PR TITLE
チャンネルガチャ本体の前にメッセージを追加するオプションを追加

### DIFF
--- a/ruboty-channel-gacha.rb
+++ b/ruboty-channel-gacha.rb
@@ -27,7 +27,7 @@ module Ruboty
       end
 
       def pre_message
-        @option.split('=', 2).tap(&:shift) if with_pre_message?
+        @option.split('=', 2)[1] if with_pre_message?
       end
 
       def main_message(channel)

--- a/ruboty-channel-gacha.rb
+++ b/ruboty-channel-gacha.rb
@@ -13,14 +13,17 @@ module Ruboty
 
       def channel_gacha(message)
         set_option(message)
-        message.reply pre_message if with_pre_message?
-        message.reply main_message(selected_channel)
+        message.reply messages.join("\n")
       end
 
       private
 
       def set_option(message)
         @option = message.match_data['option']
+      end
+
+      def messages
+        [pre_message, main_message(selected_channel)].compact
       end
 
       def pre_message
@@ -48,7 +51,7 @@ module Ruboty
       end
 
       def with_pre_message?
-        @option =~ %r!\A-pre!
+        @option =~ /\A-pre/
       end
 
       def fetch_channels

--- a/ruboty-channel-gacha.rb
+++ b/ruboty-channel-gacha.rb
@@ -12,16 +12,22 @@ module Ruboty
       )
 
       def channel_gacha(message)
-        message.tap(&set_option).reply format(selected_channel)
+        set_option(message)
+        message.reply pre_message if with_pre_message?
+        message.reply main_message(selected_channel)
       end
 
       private
 
-      def set_option
-        -> (message) { @option = message.match_data['option'] }
+      def set_option(message)
+        @option = message.match_data['option']
       end
 
-      def format(channel)
+      def pre_message
+        @option.split('=', 2).tap(&:shift) if with_pre_message?
+      end
+
+      def main_message(channel)
         <<~MESSAGE
           チャンネル名: ##{channel.name}
           トピック: #{channel.topic.presence || '未設定'}
@@ -39,6 +45,10 @@ module Ruboty
 
       def reload?
         @option == '-r'
+      end
+
+      def with_pre_message?
+        @option =~ %r!\A-pre!
       end
 
       def fetch_channels


### PR DESCRIPTION
### 概要
ruboty-cronを使用して定期的にチャンネルガチャを流しているが、ruboty-cronは実行コマンドをチャンネルに流さないので唐突にチャンネルガチャ本体のメッセージが流れてくる。
ユーザーにはこれが何なのか分かりづらい。(実際に指摘も頂いた)
そのため、チャンネルガチャ本体の前にメッセージを追加するオプションを追加した。

### 仕様
- オプションとして `-pre=message_content` を付けると本体のメッセージの前に `message_content` を追加する
  - 単純な実装とするため、 `-r` との併用は今のところできないようにしている

fixed #27 