### PR TITLE
トピック・説明は設定されていない場合出力しないように修正

### DIFF
--- a/ruboty-channel-gacha.rb
+++ b/ruboty-channel-gacha.rb
@@ -31,11 +31,19 @@ module Ruboty
       end
 
       def main_message(channel)
-        <<~MESSAGE
-          チャンネル名: ##{channel.name}
-          トピック: #{channel.topic.presence || '未設定'}
-          説明: #{channel.purpose.presence || '未設定'}
-        MESSAGE
+        [channel_name(channel), topic(channel), purpose(channel)].compact.join("\n")
+      end
+
+      def channel_name(channel)
+        "チャンネル名: ##{channel.name}"
+      end
+
+      def topic(channel)
+        "トピック: #{channel.topic}" if channel.topic.present?
+      end
+
+      def purpose(channel)
+        "説明: #{channel.purpose}" if channel.purpose.present?
       end
 
       def selected_channel


### PR DESCRIPTION
### 目的
これまではトピック・目的が設定されていない場合は `未設定` の文言を出力していたが、これではユーザーにトピック・目的を設定しないといけないという印象をあたえてしまう。
そのため、設定されていない場合はその項目を出力しないようにして設定していないことを目立たせないようにする。

### 仕様
- チャンネル名はこれまで通り常に出力する
  - 設定されないことがないため
- トピック・目的は設定されている場合のみ出力し、設定されていない場合は出力しない