### PR TITLE
Supply "--rm" option to docker-compose command sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ pong
 If you have docker environment, also can development by run below command
 
 ```bash
-$ docker-compose run ruboty
+$ docker-compose run --rm ruboty
 > ruboty ping
 pong
 ```


### PR DESCRIPTION
The `run` command of `docker-compose` without `--rm` option is preserving the container after the run, whereas not reusing containers in the README's explanation.

Therefore, there should be no need to save.

* * *

If you want to see the list of preserved(stopped) containers of your ruboty, try that command:

    docker container ls --all --filter ancestor=ruboty-ruby-jp_ruboty