### PR TITLE
Link to channel of japanese

### DIFF
--- a/ruboty-channel-gacha.rb
+++ b/ruboty-channel-gacha.rb
@@ -35,7 +35,7 @@ module Ruboty
       end
 
       def channel_name(channel)
-        "チャンネル名: ##{channel.name}"
+        "チャンネル名: <##{channel.id}>"
       end
 
       def topic(channel)
@@ -89,7 +89,7 @@ module Ruboty
       def channel_information
         -> (channel) do
           OpenStruct.new({
-            name: channel['name'],
+            id: channel['id'],
             topic: channel['topic']['value'],
             purpose: channel['purpose']['value']
           })


### PR DESCRIPTION
Now, doesn't link to channel of japanese.
If use channel ID, will be linked to channel.

Link text syntax are `<#channel_id>`.
https://api.slack.com/reference/surfaces/formatting#linking-channels

---
For example, if `#おなかすいた` channel is sampled, ruboty return following text:
```
> ruboty channel_gacha
チャンネル名: <#CMJS1M886>
説明: :onaka_heru_woman: おなかすいたときにどうぞ
```