### PR TITLE
チャンネルガチャのハンドラーを責務ごとにクラス・モジュールに分割

### DIFF
--- a/ruboty-channel-gacha.rb
+++ b/ruboty-channel-gacha.rb
@@ -16,44 +16,46 @@ module Ruboty
                                      .then { Replies::ChannelGacha.create(_1, option.pre_message) }
       end
     end
+  end
+end
 
-    module Replies
-      module ChannelGacha
-        class << self
-          def create(channels, pre_message)
-            messages(channels, pre_message).join("\n")
-          end
-
-          private
-
-          def messages(channels, pre_message)
-            [pre_message, channels.sample.channel_information].compact
-          end
-        end
+module Replies
+  module ChannelGacha
+    class << self
+      def create(channels, pre_message)
+        messages(channels, pre_message).join("\n")
       end
-    end
 
-    module Options
-      class Channel
-        def initialize(message)
-          @option = message.match_data['option']
-        end
+      private
 
-        def reload?
-          @option == '-r'
-        end
-
-        def pre_message
-          @option.split('=', 2)[1] if with_pre_message?
-        end
-
-        def with_pre_message?
-          @option =~ /\A-pre/
-        end
+      def messages(channels, pre_message)
+        [pre_message, channels.sample.channel_information].compact
       end
     end
   end
+end
 
+module Options
+  class Channel
+    def initialize(message)
+      @option = message.match_data['option']
+    end
+
+    def reload?
+      @option == '-r'
+    end
+
+    def pre_message
+      @option.split('=', 2)[1] if with_pre_message?
+    end
+
+    def with_pre_message?
+      @option =~ /\A-pre/
+    end
+  end
+end
+
+module RubyJP
   class Cache
     @store ||= ActiveSupport::Cache::MemoryStore.new
 
@@ -68,71 +70,69 @@ module Ruboty
     end
   end
 
-  module RubyJP
-    class Channel
-      attr_writer :id, :topic, :purpose
+  class Channel
+    attr_writer :id, :topic, :purpose
 
-      def initialize(channel)
-        @id = channel['id']
-        @topic = channel['topic']['value']
-        @purpose = channel['purpose']['value']
+    def initialize(channel)
+      @id = channel['id']
+      @topic = channel['topic']['value']
+      @purpose = channel['purpose']['value']
+    end
+
+    class << self
+      def cache(reload: false)
+        Cache.fetch('channels', reload: reload) { all }
       end
 
-      class << self
-        def cache(reload: false)
-          Cache.fetch('channels', reload: reload) { all }
-        end
-
-        def all
-          Ruboty::SlackApi::Channel.all_public_channels.map(&method(:new))
-        end
-      end
-
-      def channel_information
-        [channel_name, topic, purpose].compact.join("\n")
-      end
-
-      def channel_name
-        "チャンネル名: <##{@id}>"
-      end
-
-      def topic
-        "トピック: #{@topic}" if @topic.present?
-      end
-
-      def purpose
-        "説明: #{@purpose}" if @purpose.present?
+      def all
+        SlackApi::Channel.all_public_channels.map(&method(:new))
       end
     end
+
+    def channel_information
+      [channel_name, topic, purpose].compact.join("\n")
+    end
+
+    def channel_name
+      "チャンネル名: <##{@id}>"
+    end
+
+    def topic
+      "トピック: #{@topic}" if @topic.present?
+    end
+
+    def purpose
+      "説明: #{@purpose}" if @purpose.present?
+    end
   end
+end
 
-  module SlackApi
-    class Channel
-      class << self
-        def all_public_channels
-          new.fetch_public_channels
-        end
+module SlackApi
+  class Channel
+    class << self
+      def all_public_channels
+        new.fetch_public_channels
       end
+    end
 
-      def fetch_public_channels
-        channels, next_cursor = [], nil
-        until next_cursor&.empty?
-          response = request_params(next_cursor).then(&client.method(:conversations_list))
-          next_cursor = response['response_metadata']['next_cursor']
-          channels.concat(response['channels'])
-        end
-        channels
+    def fetch_public_channels
+      channels, next_cursor = [], nil
+      until next_cursor&.empty?
+        response = request_params(next_cursor).then(&client.method(:conversations_list))
+        next_cursor = response['response_metadata']['next_cursor']
+        channels.concat(response['channels'])
       end
+      channels
+    end
 
-      private
+    private
 
-      def client
-        Slack::Client.new(token: ENV.fetch('SLACK_TOKEN'))
-      end
+    def client
+      Slack::Client.new(token: ENV.fetch('SLACK_TOKEN'))
+    end
 
-      def request_params(next_cursor)
-        { exclude_archived: true, limit: 200 }.tap { _1.merge!({ cursor: next_cursor }) if next_cursor.present? }
-      end
+    def request_params(next_cursor)
+      { exclude_archived: true, limit: 200 }.tap { _1.merge!({ cursor: next_cursor }) if next_cursor.present? }
     end
   end
 end

--- a/ruboty-channel-gacha.rb
+++ b/ruboty-channel-gacha.rb
@@ -11,8 +11,8 @@ module Ruboty
       )
 
       def channel_gacha(message)
-        set_option(message)
-        message.reply messages.join("\n")
+        option = Options::Channel.new(message)
+        message.reply messages(option).join("\n")
       end
 
       private
@@ -21,28 +21,36 @@ module Ruboty
         @option = message.match_data['option']
       end
 
-      def messages
-        [pre_message, selected_channel.channel_information].compact
-      end
-
-      def pre_message
-        @option.split('=', 2)[1] if with_pre_message?
+      def messages(option)
+        [option.pre_message, channels(option.reload?).sample.channel_information].compact
       end
 
       def selected_channel
         channels.sample
       end
 
-      def channels
-        @channels = (reload? || !@channels) ? Ruboty::RubyJP::Channel.all : @channels
+      def channels(reload)
+        @channels = (reload || !@channels) ? Ruboty::RubyJP::Channel.all : @channels
       end
+    end
 
-      def reload?
-        @option == '-r'
-      end
+    module Options
+      class Channel
+        def initialize(message)
+          @option = message.match_data['option']
+        end
 
-      def with_pre_message?
-        @option =~ /\A-pre/
+        def reload?
+          @option == '-r'
+        end
+
+        def pre_message
+          @option.split('=', 2)[1] if with_pre_message?
+        end
+
+        def with_pre_message?
+          @option =~ /\A-pre/
+        end
       end
     end
   end

--- a/ruboty-channel-gacha.rb
+++ b/ruboty-channel-gacha.rb
@@ -118,7 +118,7 @@ module SlackApi
     def fetch_public_channels
       channels, next_cursor = [], nil
       until next_cursor&.empty?
-        response = request_params(next_cursor).then(&client.method(:conversations_list))
+        response = client.conversations_list request_params(next_cursor)
         next_cursor = response['response_metadata']['next_cursor']
         channels.concat(response['channels'])
       end

--- a/ruboty-channel-gacha.rb
+++ b/ruboty-channel-gacha.rb
@@ -11,7 +11,7 @@ module Ruboty
       )
 
       def channel_gacha(message)
-        option = Options::Channel.new(message)
+        option = Options::Channel.new(message.match_data['option'])
         message.reply RubyJP::Channel.cache(reload: option.reload?)
                                      .then { Replies::ChannelGacha.create(_1, option.pre_message) }
       end
@@ -37,8 +37,8 @@ end
 
 module Options
   class Channel
-    def initialize(message)
-      @option = message.match_data['option']
+    def initialize(option)
+      @option = option
     end
 
     def reload?

--- a/ruboty-channel-gacha.rb
+++ b/ruboty-channel-gacha.rb
@@ -17,16 +17,8 @@ module Ruboty
 
       private
 
-      def set_option(message)
-        @option = message.match_data['option']
-      end
-
       def messages(option)
         [option.pre_message, channels(option.reload?).sample.channel_information].compact
-      end
-
-      def selected_channel
-        channels.sample
       end
 
       def channels(reload)

--- a/ruboty-channel-gacha.rb
+++ b/ruboty-channel-gacha.rb
@@ -12,7 +12,7 @@ module Ruboty
 
       def channel_gacha(message)
         option = Options::Channel.new(message.match_data['option'])
-        message.reply RubyJP::Channel.cache(reload: option.reload?)
+        message.reply RubyJP::Channel.all(reload: option.reload?)
                                      .then { Replies::ChannelGacha.create(_1, option.pre_message) }
       end
     end
@@ -80,12 +80,14 @@ module RubyJP
     end
 
     class << self
-      def cache(reload: false)
-        Cache.fetch('channels', reload: reload) { all }
+      def all(reload: false)
+        cache(reload: reload) { SlackApi::Channel.new.fetch_public_channels.map(&method(:new)) }
       end
 
-      def all
-        SlackApi::Channel.new.fetch_public_channels.map(&method(:new))
+      private
+
+      def cache(reload: false, &block)
+        Cache.fetch('channels', reload: reload, &block)
       end
     end
 

--- a/ruboty-channel-gacha.rb
+++ b/ruboty-channel-gacha.rb
@@ -13,7 +13,7 @@ module Ruboty
       def channel_gacha(message)
         option = Options::Channel.new(message.match_data['option'])
         message.reply RubyJP::Channel.all(reload: option.reload?)
-                                     .then { Replies::ChannelGacha.create(_1, option.pre_message) }
+                                     .then { |channels| Replies::ChannelGacha.create(channels, option.pre_message) }
       end
     end
   end

--- a/ruboty-channel-gacha.rb
+++ b/ruboty-channel-gacha.rb
@@ -85,7 +85,7 @@ module RubyJP
       end
 
       def all
-        SlackApi::Channel.all_public_channels.map(&method(:new))
+        SlackApi::Channel.new.fetch_public_channels.map(&method(:new))
       end
     end
 
@@ -109,16 +109,14 @@ end
 
 module SlackApi
   class Channel
-    class << self
-      def all_public_channels
-        new.fetch_public_channels
-      end
+    def initialize
+      @client = client
     end
 
     def fetch_public_channels
       channels, next_cursor = [], nil
       until next_cursor&.empty?
-        response = client.conversations_list request_params(next_cursor)
+        response = @client.conversations_list request_params(next_cursor)
         next_cursor = response['response_metadata']['next_cursor']
         channels.concat(response['channels'])
       end

--- a/ruboty-channel-gacha.rb
+++ b/ruboty-channel-gacha.rb
@@ -12,17 +12,29 @@ module Ruboty
 
       def channel_gacha(message)
         option = Options::Channel.new(message)
-        message.reply messages(option).join("\n")
+        message.reply channels(option.reload?).then { Replies::ChannelGacha.create(_1, option.pre_message) }
       end
 
       private
 
-      def messages(option)
-        [option.pre_message, channels(option.reload?).sample.channel_information].compact
-      end
-
       def channels(reload)
         @channels = (reload || !@channels) ? Ruboty::RubyJP::Channel.all : @channels
+      end
+    end
+
+    module Replies
+      module ChannelGacha
+        class << self
+          def create(channels, pre_message)
+            messages(channels, pre_message).join("\n")
+          end
+
+          private
+
+          def messages(channels, pre_message)
+            [pre_message, channels.sample.channel_information].compact
+          end
+        end
       end
     end
 

--- a/ruboty-channel-gacha.rb
+++ b/ruboty-channel-gacha.rb
@@ -65,7 +65,7 @@ module RubyJP
       end
 
       def fetch(name, reload: false, &block)
-        store.tap { _1.clear if reload }.fetch(name, &block)
+        store.tap { _1.delete(name) if reload }.fetch(name, &block)
       end
     end
   end


### PR DESCRIPTION
### 概要
#25 (新着チャンネル通知が欲しい) の実装にあたり、チャンネルガチャと実装のかぶる箇所がかなりあるため、再利用できるよう責務ごとにクラスやモジュールに分割するリファクタリングを実施した

### 追加したクラス・モジュール
- Ruboty::SlackApi::Channel
  - Slack API の チャンネル情報に関するクラス
- Ruboty::RubyJP::Channel
  - ruby-jp の チャンネル情報を格納するクラス
- Ruboty::Cache
  - キャッシュを管理するクラス
- Ruboty::Handlers::Replies::ChannelGacha
  - ハンドラー毎の応答メッセージを組み立てるモジュール(今回はチャンネルガチャのみ)
- Ruboty::Handlers::Options::Channel
  - チャンネルに関するハンドラーのオプションを司るクラス