### PR TITLE
Update slop gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,7 +98,7 @@ GEM
       faraday_middleware (~> 0.10.0)
       faye-websocket (~> 0.10.6)
       multi_json (~> 1.0, >= 1.0.3)
-    slop (4.7.0)
+    slop (4.8.2)
     thread_safe (0.3.6)
     twitter (6.2.0)
       addressable (~> 2.3)


### PR DESCRIPTION
To fix warnings:

```
% docker-compose run --rm ruboty
Starting ruboty-ruby-jp_redis_1 ... done
/usr/local/lib/ruby/gems/2.7.0/gems/slop-4.7.0/lib/slop.rb:23: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/usr/local/lib/ruby/gems/2.7.0/gems/slop-4.7.0/lib/slop/options.rb:27: warning: The called method `initialize' is defined here
/usr/local/lib/ruby/gems/2.7.0/gems/slop-4.7.0/lib/slop/options.rb:32: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/usr/local/lib/ruby/gems/2.7.0/gems/slop-4.7.0/lib/slop/parser.rb:13: warning: The called method `initialize' is defined here
/usr/local/lib/ruby/gems/2.7.0/gems/slop-4.7.0/lib/slop/options.rb:55: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/usr/local/lib/ruby/gems/2.7.0/gems/slop-4.7.0/lib/slop/option.rb:30: warning: The called method `initialize' is defined here
/usr/local/lib/ruby/gems/2.7.0/gems/slop-4.7.0/lib/slop/options.rb:85: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/usr/local/lib/ruby/gems/2.7.0/gems/slop-4.7.0/lib/slop/options.rb:51: warning: The called method `on' is defined here
Type `exit` or `quit` to end the session.
>
```