### PR TITLE
Notify new channel creation to #new_channel

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem 'parser'
 gem 'ruboty-replace'
 gem "ruboty-slack_rtm", require: false
 gem 'ruboty-slack_rtm-emoji_changed'
+gem 'ruboty-slack_rtm-channel_created'
 gem 'ruboty-redis'
 gem 'ruboty-cron'
 gem 'ruboty-rurema'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,6 +107,8 @@ GEM
       ruboty (>= 1.1.4)
       slack-api (~> 1.6)
       websocket-client-simple (>= 0.5.0)
+    ruboty-slack_rtm-channel_created (0.1.1)
+      ruboty-slack_rtm
     ruboty-slack_rtm-emoji_changed (0.1.0)
     ruboty-zoi (1.1.0)
       ruboty
@@ -161,6 +163,7 @@ DEPENDENCIES
   ruboty-replace
   ruboty-rurema
   ruboty-slack_rtm
+  ruboty-slack_rtm-channel_created
   ruboty-slack_rtm-emoji_changed
   ruboty-zoi
   slack-api


### PR DESCRIPTION
 ## 概要

新しくチャンネルが作成されると、`#new_channel` か `ENV["SLACK_CHANNEL_CREATED_NOTIFY_CHANNEL"]` で設定されたチャネルに通知します。

close: https://github.com/ruby-jp/ruboty-ruby-jp/issues/25


## 通知内容

![image](https://github.com/ruby-jp/ruboty-ruby-jp/assets/52617472/9e012922-0e32-45c8-9912-b2dd7ab70584)

## マージしたらやらないといけないこと

- `#new_channel` か環境変数で指定するチャンネルの作成
- そのチャンネルにrubotyを呼ぶ

## コード

ruboty-slack_rtm-emoji_changed を参考にしてます

https://github.com/ima1zumi/ruboty-slack_rtm-channel_created/blob/main/lib/ruboty/slack_rtm/channel_created.rb